### PR TITLE
Try to make example and API explanation clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,239 +7,129 @@ Trying to add undo/redo in JS can be a nightmare. If anything gets mutated in an
 So this package takes these underlying strengths of Elm and turns them into a small package that lets you drop in undo/redo functionality in just a few lines of code!
 
 
-### How it works
+## How it works
 
 The library is centered around a single data structure, the `UndoList`.
 
 ```elm
-type UndoList state = UndoList (List state) state (List state)
+type UndoList state =
+    UndoList (List state) state (List state)
 ```
 
-An `UndoList` contains a list of past state, a present state, and a list of future states where the head of 
-the past list is the previous state and the head of the future list is the next state.
+An `UndoList` contains a list of past state, a present state, and a list of future states. Since it keeps track of the past, present, and future, undo and redo are just a matter of sliding the present around a bit.
 
-```elm
-UndoList past present future
-```
 
-So, say you have a function to view a given state
+## Example
 
-```elm
-view : state -> Html
-```
-
-You can use this function on an `UndoList` by extracting the present value (for example with the present function)
-
-```elm
-view (present states)
-
--- where states : UndoList state
--- given present : UndoList state -> state
-```
-
-If you wish to undo, it is as simple as calling the `undo` function on the `UndoList`
-
-```elm
-view (present (undo states))
-
--- undo : UndoList state -> UndoList state
-```
-
-Furthermore, given the simplicity of the `UndoList` data structure, the `undo` function has a trivial 
-implementation.
-
-```elm
-undo : UndoList state -> UndoList state
-undo (UndoList past present future) = 
-  case past of 
-    [] -> 
-      UndoList past present future
-    previous :: pastStates ->
-      UndoList pastStates previous (present :: future)
-```
-
-All you need to do is set the previous state as the present state and add the old present state to the list of 
-future states.
-
-Redo is defined just as trivially. 
-
-### How do you use it
-
-Suppose you have this very simple counter application.
+We will start with a very simple counter application. There is a button, and when it is clicked, it increments a counter.
 
 ```elm
 import Html
 import Html.Events exposing (onClick)
-import Signal exposing (mailbox)
+import Signal
 
-initial = 0
 
-update _ state = state + 1
+initialModel =
+  0
 
-view address state = 
+update _ model =
+  model + 1
+
+view address model = 
   Html.div 
       []
       [ Html.button 
-            [ onClick address () ]
-            [ Html.text "Increment" ]
+          [ onClick address () ]
+          [ Html.text "Increment" ]
       , Html.div 
-            []
-            [ Html.text (toString state) ]
+          []
+          [ Html.text (toString model) ]
       ]
 
-{address, signal} = mailbox ()
+actions =
+  Signal.mailbox ()
 
 main = 
-  Signal.map (view address)
-    (Signal.foldp update initial signal)
+  Signal.map (view actions.address)
+    (Signal.foldp update initialModel actions.signal)
 ```
 
-Where you have a button that, when clicked, increments a counter. 
-
-If we consider the [Elm Architecture](https://github.com/evancz/elm-architecture-tutorial), then this application
-adheres to it with the following form:
-
-```elm
-initial : Int 
-
-update : () -> Int -> Int 
-
-view : Address () -> Int -> Html 
-
-address : Address ()
-
-signal : Signal ()
-
-main : Signal Html
-main = 
-  Signal.map (view address)
-    (Signal.foldp update initial signal)
-```
-
-
-Now, suppose that we wish to add a button that performs undo. To support this feature we need to :
-
-**1) Import UndoList**
+After we write that up, we decide it would be nice to have an undo button. The next code block is the same program updated to use the `UndoList` module to add this functionality. It is in one big block because it is mostly the same as the original, and we will go into the differences afterwards.
 
 ```elm
 import Html
 import Html.Events exposing (onClick)
-import Signal exposing (mailbox)
-import UndoList exposing (UndoList(..), Action(..), fresh, apply)
-```
+import Signal
+import UndoList
 
-**2) Convert the initial model from `Int` to `UndoList Int`**
+initialModel =
+  UndoList.fresh 0
 
-```elm
-initial : UndoList Int 
-initial = fresh 0
-
--- fresh : a -> UndoList a
--- fresh creates an undo list with neither past nor future states
-```
-
-**3) Send undo list actions as opposed to simply `()` and add the undo button**
-
-```elm
--- make sure you extract the present state somehow
--- as you are passed the entire undo list
-view : Address (Action ()) -> UndoList Int -> Html
-view address (UndoList _ state _ ) = 
-  Html.div 
-      []
-      [ Html.button 
-            [ onClick address (New ()) ]
-            [ Html.text "Increment" ]
-      , Html.button 
-            [ onClick address Undo ]
-            [ Html.text "Undo" ]
-      , Html.div 
-            []
-            [ Html.text (toString state) ] 
-      ]
-```
-
-`elm-redo-undo` provides a default `Action` type to wrap all your actions. It is defined as follows:
-
-```elm
-type Action a 
-  = Reset       -- reset the state to the oldest state, removing all other states 
-  | Undo        -- go back to the previous state (this is a no-op if there is no such state)
-  | Redo        -- go to the next state (this is a no-op if there is no such state)
-  | Forget      -- remove all past states
-  | New a       -- add a new value or action. This removes all future states
-```
-
-If we simply wrap all actions send to the address with `New`, your application will be unchanged and will 
-just accumulate the past states without influencing the correctness of your code. 
-
-
-**4) Modify the mailbox to support undo list actions**
-
-```elm
-{address, signal} = mailbox Reset
-
--- address : Address (Action ())
--- signal : Signal (Action ())
-```
-
-Reset is harmless choice for an initial `Action` because it is a no-op on a fresh undo list.
-
-
-**5) Apply the `update` function**
-
-```elm
-main : Signal Html
-main = 
-  Signal.map (view address)
-    (Signal.foldp (apply update) initial signal)
-```
-
-`apply` converts a function that updates a `state` given some `action` into a function that updates an 
-`UndoList state` given some `Action action`.
-
-```elm
-apply :  (action -> state -> state) 
-      -> (Action action -> UndoList state -> UndoList state)
-```
-
-**6) That's it!**
-
-You're done. Seriously. You've just added undo to this counter without manually dealing with the undo logic. 
-
-
-Here's the whole code to convince yourself of this:
-
-```elm
-import Html
-import Html.Events exposing (onClick)
-import Signal exposing (mailbox)
-import UndoList exposing (UndoList(..), Action(..), fresh, apply)
-
-initial = fresh 0
-
-update _ state = state + 1
+update _ state =
+  state + 1
 
 view address (UndoList _ state _ ) = 
   Html.div 
       []
       [ Html.button 
-            [ onClick address (New ()) ]
-            [ Html.text "Increment" ]
+          [ onClick address (UndoList.New ()) ]
+          [ Html.text "Increment" ]
       , Html.button 
-            [ onClick address Undo ]
-            [ Html.text "Undo" ]
+          [ onClick address UndoList.Undo ]
+          [ Html.text "Undo" ]
       , Html.div 
-            []
-            [ Html.text (toString state) ] 
+          []
+          [ Html.text (toString state) ] 
       ]
       
-{address, signal} = mailbox Reset
+actions =
+  Signal.mailbox UndoList.Reset
 
 main = 
-  Signal.map (view address)
-    (Signal.foldp (apply update) initial signal)
+  Signal.map (view actions.address)
+    (Signal.foldp (UndoList.apply update) initialModel actions.signal)
 ```
 
-The best thing about this appraoch is that it is very general. The `update` function did not have to change
-at all, and the `view` function only required minimal changes. 
+The code looks pretty much the same, but we added a few things.
+
+  1. We import the `UndoList` module.
+  2. Our `initialModel` is now instantiated as a `fresh` `UndoList` which means we set the present value, but the past and future are totally blank.
+  3. The `view` grabs the present value from the `UndoList`
+  4. We added a new button to `view` that reports an `Undo` action.
+  5. We use `UndoList.apply` in the `foldp` to handle any undo/redo stuff
+
+To summarize this in a less technical way. We said we want to keep track of history, we added a button that describes how to move through history, and we added one function call that makes this all work together. Three little changes!
+
+The crazy thing is that this same pattern will work no matter how large your app gets. You do not have to think about any nasty details of undo/redo, you make a tiny number of additions and the vast majority of the code stays exactly the same!
+
+
+## More Details
+
+This API is designed to work really nicely with [The Elm Architecture][arch], so it exposes an `Action` type that can easily be added to your existing ones:
+
+[arch]: https://github.com/evancz/elm-architecture-tutorial/
+
+```elm
+type Action subaction
+    = Reset
+    | Redo
+    | Undo
+    | Forget
+    | New subaction
+```
+
+You can specify all the normal actions of your application with `New` but you now have `Undo`, `Redo`, etc.
+
+This becomes really powerful when paired with `apply` which handles all of the `UndoList` actions seamlessly.
+
+```elm
+apply
+  : (action -> model -> model)
+  -> (Action action -> UndoList model -> UndoList model)
+```
+
+It lets you write a normal `update` function and then upgrade it to a function that works on `UndoLists`.
+
+The API has a lot more cool stuff, so [check it out][docs].
+
+[docs]: http://package.elm-lang.org/packages/TheSeamau5/elm-undo-redo/latest


### PR DESCRIPTION
Okay, this is a bigger change and it may look crazy, but give it a chance! :) I'm following some general rules that I think help:
- Mixing code and explanation heavily is often more confusing than helpful. I think the [Making Pong](http://elm-lang.org/blog/Pong.elm) is hurt by mixing text and code for such a long example. It _can_ work as code comments, but mixing text and code rarely works in my experience.
- Fewer words can often be way clearer, especially if you pick the right code examples and show code snippets in the right order and in such a way that you don't need much context besides the section header.
- People checking out the library want to see an example right out the gate, learning all the details is only necessary if you already decided you want to use it. With this PR, I juxtapose the before and after of the counter very directly. People can hop between and see it's really non-invasive. At that point they'll say, "what exactly is going on here?" and be met with the "More Details" section that gives insight into the particulars of how things work.

So the goal is to give increasing amounts of technical depth. This way people can't get lost before they understand the big picture. I think some of the text could be improved, but I think this general setup will work better for people.
