### PR TITLE
Changed UndoList to record type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Easy undo in Elm with elm-undo-redo
 
 This package makes dealing with undo extremely easy in Elm. By enforcing immutability, Elm applications
-have the benefit that, at any given time, the entire state of the application is known. Therefore, theoretically 
-undo is trivial as one merely needs to capture the past states and then move back one state in the past. This is 
-exactly what this library does. Furthermore, by embracing functional programming an a clear and simple functional 
+have the benefit that, at any given time, the entire state of the application is known. Therefore, theoretically
+undo is trivial as one merely needs to capture the past states and then move back one state in the past. This is
+exactly what this library does. Furthermore, by embracing functional programming an a clear and simple functional
 reactive model, it is possible to provide abstractions to support undo/redo in absolutely any Elm application.
 
 
@@ -12,15 +12,15 @@ reactive model, it is possible to provide abstractions to support undo/redo in a
 The library is centered around a single data structure, the `UndoList`.
 
 ```elm
-type UndoList state = UndoList (List state) state (List state)
+type alias UndoList state =
+  { past    : List state
+  , present : state
+  , future  : List state
+  }
 ```
 
-An `UndoList` contains a list of past state, a present state, and a list of future states where the head of 
+An `UndoList` contains a list of past state, a present state, and a list of future states where the head of
 the past list is the previous state and the head of the future list is the next state.
-
-```elm
-UndoList past present future
-```
 
 So, say you have a function to view a given state
 
@@ -45,23 +45,23 @@ view (present (undo states))
 -- undo : UndoList state -> UndoList state
 ```
 
-Furthermore, given the simplicity of the `UndoList` data structure, the `undo` function has a trivial 
+Furthermore, given the simplicity of the `UndoList` data structure, the `undo` function has a trivial
 implementation.
 
 ```elm
 undo : UndoList state -> UndoList state
-undo (UndoList past present future) = 
-  case past of 
-    [] -> 
+undo {past, present, future} =
+  case past of
+    [] ->
       UndoList past present future
     previous :: pastStates ->
       UndoList pastStates previous (present :: future)
 ```
 
-All you need to do is set the previous state as the present state and add the old present state to the list of 
+All you need to do is set the previous state as the present state and add the old present state to the list of
 future states.
 
-Redo is defined just as trivially. 
+Redo is defined just as trivially.
 
 ### How do you use it
 
@@ -76,42 +76,42 @@ initial = 0
 
 update _ state = state + 1
 
-view address state = 
-  Html.div 
+view address state =
+  Html.div
       []
-      [ Html.button 
+      [ Html.button
             [ onClick address () ]
             [ Html.text "Increment" ]
-      , Html.div 
+      , Html.div
             []
             [ Html.text (toString state) ]
       ]
 
 {address, signal} = mailbox ()
 
-main = 
+main =
   Signal.map (view address)
     (Signal.foldp update initial signal)
 ```
 
-Where you have a button that, when clicked, increments a counter. 
+Where you have a button that, when clicked, increments a counter.
 
 If we consider the [Elm Architecture](https://github.com/evancz/elm-architecture-tutorial), then this application
 adheres to it with the following form:
 
 ```elm
-initial : Int 
+initial : Int
 
-update : () -> Int -> Int 
+update : () -> Int -> Int
 
-view : Address () -> Int -> Html 
+view : Address () -> Int -> Html
 
 address : Address ()
 
 signal : Signal ()
 
 main : Signal Html
-main = 
+main =
   Signal.map (view address)
     (Signal.foldp update initial signal)
 ```
@@ -125,13 +125,13 @@ Now, suppose that we wish to add a button that performs undo. To support this fe
 import Html
 import Html.Events exposing (onClick)
 import Signal exposing (mailbox)
-import UndoList exposing (UndoList(..), Action(..), fresh, apply)
+import UndoList exposing (UndoList, Action(..), fresh, apply)
 ```
 
 **2) Convert the initial model from `Int` to `UndoList Int`**
 
 ```elm
-initial : UndoList Int 
+initial : UndoList Int
 initial = fresh 0
 
 -- fresh : a -> UndoList a
@@ -141,37 +141,36 @@ initial = fresh 0
 **3) Send undo list actions as opposed to simply `()` and add the undo button**
 
 ```elm
--- make sure you extract the present state somehow
--- as you are passed the entire undo list
+-- make sure you extract the present state
 view : Address (Action ()) -> UndoList Int -> Html
-view address (UndoList _ state _ ) = 
-  Html.div 
+view address {present} =
+  Html.div
       []
-      [ Html.button 
+      [ Html.button
             [ onClick address (New ()) ]
             [ Html.text "Increment" ]
-      , Html.button 
+      , Html.button
             [ onClick address Undo ]
             [ Html.text "Undo" ]
-      , Html.div 
+      , Html.div
             []
-            [ Html.text (toString state) ] 
+            [ Html.text (toString present) ]
       ]
 ```
 
 `elm-redo-undo` provides a default `Action` type to wrap all your actions. It is defined as follows:
 
 ```elm
-type Action a 
-  = Reset       -- reset the state to the oldest state, removing all other states 
+type Action a
+  = Reset       -- reset the state to the oldest state, removing all other states
   | Undo        -- go back to the previous state (this is a no-op if there is no such state)
   | Redo        -- go to the next state (this is a no-op if there is no such state)
   | Forget      -- remove all past states
   | New a       -- add a new value or action. This removes all future states
 ```
 
-If we simply wrap all actions send to the address with `New`, your application will be unchanged and will 
-just accumulate the past states without influencing the correctness of your code. 
+If we simply wrap all actions send to the address with `New`, your application will be unchanged and will
+just accumulate the past states without influencing the correctness of your code.
 
 
 **4) Modify the mailbox to support undo list actions**
@@ -190,22 +189,22 @@ Reset is harmless choice for an initial `Action` because it is a no-op on a fres
 
 ```elm
 main : Signal Html
-main = 
+main =
   Signal.map (view address)
     (Signal.foldp (apply update) initial signal)
 ```
 
-`apply` converts a function that updates a `state` given some `action` into a function that updates an 
+`apply` converts a function that updates a `state` given some `action` into a function that updates an
 `UndoList state` given some `Action action`.
 
 ```elm
-apply :  (action -> state -> state) 
+apply :  (action -> state -> state)
       -> (Action action -> UndoList state -> UndoList state)
 ```
 
 **6) That's it!**
 
-You're done. Seriously. You've just added undo to this counter without manually dealing with the undo logic. 
+You're done. Seriously. You've just added undo to this counter without manually dealing with the undo logic.
 
 
 Here's the whole code to convince yourself of this:
@@ -214,32 +213,32 @@ Here's the whole code to convince yourself of this:
 import Html
 import Html.Events exposing (onClick)
 import Signal exposing (mailbox)
-import UndoList exposing (UndoList(..), Action(..), fresh, apply)
+import UndoList exposing (UndoList, Action(..), fresh, apply)
 
 initial = fresh 0
 
 update _ state = state + 1
 
-view address (UndoList _ state _ ) = 
-  Html.div 
+view address {present} =
+  Html.div
       []
-      [ Html.button 
+      [ Html.button
             [ onClick address (New ()) ]
             [ Html.text "Increment" ]
-      , Html.button 
+      , Html.button
             [ onClick address Undo ]
             [ Html.text "Undo" ]
-      , Html.div 
+      , Html.div
             []
-            [ Html.text (toString state) ] 
+            [ Html.text (toString present) ]
       ]
-      
+
 {address, signal} = mailbox Reset
 
-main = 
+main =
   Signal.map (view address)
     (Signal.foldp (apply update) initial signal)
 ```
 
-The best thing about this appraoch is that it is very general. The `update` function did not have to change
-at all, and the `view` function only required minimal changes. 
+The best thing about this approach is that it is very general. The `update` function did not have to change
+at all, and the `view` function only required minimal changes.

--- a/examples/Counter.elm
+++ b/examples/Counter.elm
@@ -1,7 +1,7 @@
 import Html
 import Html.Events exposing (onClick)
 import Signal exposing (mailbox)
-import UndoList exposing (UndoList(..), Action(..), fresh, apply)
+import UndoList exposing (UndoList, Action(..), fresh, apply)
 
 -------------------------------
 -- Version with undo support --
@@ -11,7 +11,7 @@ initial = fresh 0
 
 update _ state = state + 1
 
-view address (UndoList _ state _ ) =
+view address {present} =
   Html.div
       []
       [ Html.button
@@ -22,7 +22,7 @@ view address (UndoList _ state _ ) =
             [ Html.text "Undo" ]
       , Html.div
             []
-            [ Html.text (toString state) ]
+            [ Html.text (toString present) ]
       ]
 
 {address, signal} = mailbox Reset

--- a/src/UndoList/Decode.elm
+++ b/src/UndoList/Decode.elm
@@ -7,7 +7,7 @@ Provides JSON decoders for Timelines and UndoList Actions.
 @docs undolist, action
 -}
 
-import UndoList     exposing (UndoList(..), Action(..))
+import UndoList     exposing (UndoList, Action(..))
 import Json.Decode  exposing (Decoder, (:=), list, string, object3, oneOf, customDecoder)
 
 {-| Decode an undo-list given a decoder of state.

--- a/src/UndoList/Encode.elm
+++ b/src/UndoList/Encode.elm
@@ -8,7 +8,7 @@ Provides JSON encoders for Timelines and UndoList Actions.
 
 -}
 
-import UndoList     exposing (UndoList(..), Action(..))
+import UndoList     exposing (UndoList, Action(..))
 import Json.Encode  exposing (Value, object, list, string)
 
 {-| Encode an undolist of JSON values.
@@ -18,7 +18,7 @@ Best paired with the `map` function from UndoList.
       UndoList.map stateEncoder >> undolist
 -}
 undolist : UndoList Value -> Value
-undolist (UndoList past present future) =
+undolist {past, present, future} =
   object
     [ ("past"   , list past   )
     , ("present", present     )

--- a/src/UndoList/Random.elm
+++ b/src/UndoList/Random.elm
@@ -8,7 +8,7 @@ Provides random undolist and undolist action generators.
 -}
 
 
-import UndoList     exposing (UndoList(..), Action(..))
+import UndoList     exposing (UndoList, Action(..))
 import Random       exposing (Generator, list)
 import Random.Extra exposing (map, map3, frequency, constant)
 

--- a/src/UndoList/Shrink.elm
+++ b/src/UndoList/Shrink.elm
@@ -9,14 +9,14 @@ Provides shrinking strategies for timelines and actions.
 -}
 
 import Shrink   exposing (Shrinker, map, list)
-import UndoList exposing (UndoList(..), Action(..))
+import UndoList exposing (UndoList, Action(..))
 import List
 
 
 {-| Shrink an undo-list of states given a shrinker of states.
 -}
 undolist : Shrinker state -> Shrinker (UndoList state)
-undolist shrinker (UndoList past present future) =
+undolist shrinker {past, present, future} =
   let
       --pasts : List (List state)
       pasts = list shrinker past

--- a/tests/Test.elm
+++ b/tests/Test.elm
@@ -5,7 +5,7 @@ import Check.Runner.Browser exposing (..)
 import Test.Investigator.UndoList exposing (..)
 import Test.Investigator.Action exposing (..)
 
-import UndoList exposing (UndoList(..), Action(..))
+import UndoList exposing (UndoList, Action(..))
 import UndoList.Decode as Decode
 import UndoList.Encode as Encode
 import UndoList.Shrink
@@ -152,14 +152,10 @@ claim_reset_equivalent_fresh_oldest =
 
 
 fresh_oldest undolist =
-  let
-      present = UndoList.present undolist
-  in
-    undolist
-    |> UndoList.past
+  undolist.past
     |> List.reverse
     |> List.head
-    |> Maybe.withDefault present
+    |> Maybe.withDefault undolist.present
     |> UndoList.fresh
 
 
@@ -167,9 +163,9 @@ claim_new_then_undo_yields_same_present =
   claim
     "Calling new then undo preserves the original present state"
   `that`
-    (\(v, undolist) -> UndoList.new v undolist |> UndoList.undo |> UndoList.present)
+    (\(v, undolist) -> UndoList.new v undolist |> UndoList.undo |> .present)
   `is`
-    (\(_, undolist) -> UndoList.present undolist)
+    (\(_, undolist) -> undolist.present)
   `for`
     tuple (int, undolist int)
 

--- a/tests/Test/Investigator/UndoList.elm
+++ b/tests/Test/Investigator/UndoList.elm
@@ -2,7 +2,7 @@ module Test.Investigator.UndoList where
 
 
 import Check.Investigator exposing (Investigator, investigator)
-import UndoList exposing (UndoList(..), Action(..))
+import UndoList exposing (UndoList, Action(..))
 import UndoList.Random as Random
 import UndoList.Shrink as Shrink
 import Random


### PR DESCRIPTION
Implements proposal : https://github.com/TheSeamau5/elm-undo-redo/issues/2

Changed `UndoList` representation from 

``` elm
type UndoList state = UndoList (List state) state (List state)
```

to

``` elm
type alias UndoList state = 
  { past : List state
  , present : state 
  , future : List state
  }
```

This also means that the following functions were removed due to their redundancy : 

``` elm
past : UndoList a -> List a
present : UndoList a -> a
future : UndoList a -> List a
```
