### PR TITLE
Added UndoList.view function

### DIFF
--- a/examples/Counter.elm
+++ b/examples/Counter.elm
@@ -1,17 +1,17 @@
 import Html
 import Html.Events exposing (onClick)
 import Signal exposing (mailbox)
-import UndoList exposing (UndoList, Action(..), fresh, apply)
+import UndoList exposing (UndoList, Action(..))
 
 -------------------------------
 -- Version with undo support --
 -------------------------------
 
-initial = fresh 0
+initial = 0
 
 update _ state = state + 1
 
-view address {present} =
+view address state =
   Html.div
       []
       [ Html.button
@@ -22,14 +22,14 @@ view address {present} =
             [ Html.text "Undo" ]
       , Html.div
             []
-            [ Html.text (toString present) ]
+            [ Html.text (toString state) ]
       ]
 
 {address, signal} = mailbox Reset
 
 main =
-  Signal.map (view address)
-    (Signal.foldp (apply update) initial signal)
+  Signal.map (UndoList.view view address)
+    (Signal.foldp (UndoList.apply update) (UndoList.fresh initial) signal)
 
 
 

--- a/examples/Counter.elm
+++ b/examples/Counter.elm
@@ -29,7 +29,7 @@ view address state =
 
 main =
   Signal.map (UndoList.view view address)
-    (Signal.foldp (UndoList.apply update) (UndoList.fresh initial) signal)
+    (Signal.foldp (UndoList.update update) (UndoList.fresh initial) signal)
 
 
 

--- a/src/UndoList.elm
+++ b/src/UndoList.elm
@@ -24,7 +24,7 @@ module UndoList where
 -}
 
 import List
-import Signal exposing (Signal, Mailbox)
+import Signal exposing (Signal, Address, Mailbox)
 
 
 -------------------
@@ -337,6 +337,29 @@ connect {past, present, future} undolist =
 ----------------
 -- Shorthands --
 ----------------
+
+{-| Function to help not having to deal with the full undolist from with
+your actual view function.
+
+Suppose you define the following:
+
+    initial : model
+    update : action -> model -> model
+    view : Address (UndoList.Action action) -> model -> view
+    address : Address (UndoList.Action action)
+    signal : Signal (UndoList.Action action)
+
+Then, you could construct the main function as follows:
+
+    main =
+      Signal.map (UndoList.view view address)
+        (Signal.foldp (UndoList.apply update) (UndoList.fresh initial) signal)
+
+-}
+view : (Address (Action action) -> state -> view) -> (Address (Action action) -> UndoList state -> view)
+view viewer address {present} =
+  viewer address present
+
 
 {-| Analog of Signal.foldp
 


### PR DESCRIPTION
Implements view function as suggested here: https://github.com/TheSeamau5/elm-undo-redo/issues/4

@evancz  you'll like how this example now looks.

``` elm
import Html
import Html.Events exposing (onClick)
import Signal exposing (mailbox)
import UndoList exposing (UndoList, Action(..))

initial = 0

update _ state = state + 1

view address state =
  Html.div
      []
      [ Html.button
            [ onClick address (New ()) ]
            [ Html.text "Increment" ]
      , Html.button
            [ onClick address Undo ]
            [ Html.text "Undo" ]
      , Html.div
            []
            [ Html.text (toString state) ]
      ]

{address, signal} = mailbox Reset

main =
  Signal.map (UndoList.view view address)
    (Signal.foldp (UndoList.apply update) (UndoList.fresh initial) signal)
```

In this form, we can truly make the process painless. The only major changes are in the event handlers, but those changes are mandatory. Aside from that, by piling up all the transformations in the main function, we can truly have the initial model, the update function, and the view function unmodified.
